### PR TITLE
Fix typo in ONBOARDING.md

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -221,4 +221,4 @@ farmOS runs on top of Drupal. From the FarmData2 perspective this is largely tra
 
 #### drush ####
 
-For a few particular tasks related to initializtion and configuration FarmData2 makes use of [drush](https://www.drush.org/latest/) to interact with the Drupal instance on which farmOS is running. As it is discovered that more information is necessary it will be added here.
+For a few particular tasks related to initialization and configuration FarmData2 makes use of [drush](https://www.drush.org/latest/) to interact with the Drupal instance on which farmOS is running. As it is discovered that more information is necessary it will be added here.


### PR DESCRIPTION
Closes HFOSSedu-stage/GitKit-FarmData2-POSSE-2026-06#35.

Summary:
- Correct `initializtion` to `initialization` in the drush section of `ONBOARDING.md`.

Validation:
- Single documentation typo fix; no runtime tests were needed.

Automation:
- Discovered and prepared by contrib-agent running locally with gh/git/codex. Git clone transport timed out in this environment, so the final single-file commit was applied through the GitHub Contents API on the generated auto-contrib branch.