### PR TITLE
Fix initializtion typo in onboarding docs

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -221,4 +221,4 @@ farmOS runs on top of Drupal. From the FarmData2 perspective this is largely tra
 
 #### drush ####
 
-For a few particular tasks related to initializtion and configuration FarmData2 makes use of [drush](https://www.drush.org/latest/) to interact with the Drupal instance on which farmOS is running. As it is discovered that more information is necessary it will be added here.
+For a few particular tasks related to initialization and configuration FarmData2 makes use of [drush](https://www.drush.org/latest/) to interact with the Drupal instance on which farmOS is running. As it is discovered that more information is necessary it will be added here.


### PR DESCRIPTION
Summary
- Fix the `initializtion` typo to `initialization` in `ONBOARDING.md`.

Fixes #35.

Verification
- `git diff --check`

Scope
- Documentation-only typo fix in `ONBOARDING.md`.
